### PR TITLE
Correct data type of series save_no field

### DIFF
--- a/Sma5h/Mods/Sma5h.Mods.Music/Models/SeriesEntry.cs
+++ b/Sma5h/Mods/Sma5h.Mods.Music/Models/SeriesEntry.cs
@@ -9,7 +9,7 @@ namespace Sma5h.Mods.Music.Models
         public string NameId { get; set; }
         public sbyte DispOrder { get; set; }
         public sbyte DispOrderSound { get; set; }
-        public short SaveNo { get; set; }
+        public sbyte SaveNo { get; set; }
         public bool Unk1 { get; set; }
         public bool IsDlc { get; set; }
         public bool IsPatch { get; set; }

--- a/Sma5h/Mods/Sma5h.Mods.Music/MusicMods/MusicMod.cs
+++ b/Sma5h/Mods/Sma5h.Mods.Music/MusicMods/MusicMod.cs
@@ -521,7 +521,7 @@ namespace Sma5h.Mods.Music.MusicMods
                 v3ModConfig.Series = v3ModConfig.Games.GroupBy(p => p.UiSeriesId).Select(p => new SeriesConfig()
                 {
                     UiSeriesId = p.Key,
-                    SaveNo = short.MinValue,
+                    SaveNo = sbyte.MinValue,
                     Games = p.ToList()
                 }).ToList();
                 v3ModConfig.Games = null;

--- a/Sma5h/ResourceProviders/Sma5h.ResourceProviders.PrcExt/Data/Ui/Param/Database/PrcUiSeriesDatabase.cs
+++ b/Sma5h/ResourceProviders/Sma5h.ResourceProviders.PrcExt/Data/Ui/Param/Database/PrcUiSeriesDatabase.cs
@@ -28,7 +28,7 @@ namespace Sma5h.Data.Ui.Param.Database
             public sbyte DispOrderSound { get; set; }
 
             [PrcHexMapping("save_no")]
-            public short SaveNo { get; set; }
+            public sbyte SaveNo { get; set; }
 
             [PrcHexMapping(0x1c38302364)]
             public bool Unk1 { get; set; }

--- a/Sma5hMusic.GUI/ViewModels/ReactiveObjects/SeriesEntryViewModel.cs
+++ b/Sma5hMusic.GUI/ViewModels/ReactiveObjects/SeriesEntryViewModel.cs
@@ -15,7 +15,7 @@ namespace Sma5hMusic.GUI.ViewModels
         public string NameId { get; set; }
         public sbyte DispOrder { get; set; }
         public sbyte DispOrderSound { get; set; }
-        public short SaveNo { get; set; }
+        public sbyte SaveNo { get; set; }
         public bool Unk1 { get; set; }
         public bool IsDlc { get; set; }
         public bool IsPatch { get; set; }


### PR DESCRIPTION
This was done primarily for the ability to create PRCX/PRCXML patches from Sma5hMusic's output using [parcel](https://github.com/blu-dev/parcel), as the difference in data type compared to the vanilla file will cause parcel to throw an error.